### PR TITLE
Removing a var_dump in the Engine

### DIFF
--- a/lib/Engine.php
+++ b/lib/Engine.php
@@ -566,7 +566,7 @@ class Engine
 		{
 			if (!($node instanceof Node))
 			{
-				var_dump($node); continue;
+				continue;
 			}
 
 			try


### PR DESCRIPTION
Removing a var_dump in the Engine causing unwanted debug display on production site when no node is matching (example contact form submission process)
